### PR TITLE
test: 테스트 컨테이너 기능 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,9 +38,10 @@ dependencies {
     implementation 'org.postgresql:postgresql'
     implementation("org.mapstruct:mapstruct:1.5.3.Final")
     implementation("org.projectlombok:lombok-mapstruct-binding:0.2.0")
+    testImplementation 'io.zonky.test:embedded-database-spring-test:2.5.1'
+
 
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
 
     testImplementation 'org.postgresql:postgresql'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/app/src/main/java/com/joonhyeok/app/concert/domain/Seat.java
+++ b/app/src/main/java/com/joonhyeok/app/concert/domain/Seat.java
@@ -34,7 +34,7 @@ public class Seat {
     private Integer version;
 
     public boolean isReservable() {
-        return AVAILABLE == status;
+        return this.status == AVAILABLE;
     }
 
     public void reserveSeat() {

--- a/app/src/main/java/com/joonhyeok/app/queue/domain/Queue.java
+++ b/app/src/main/java/com/joonhyeok/app/queue/domain/Queue.java
@@ -16,6 +16,7 @@ import static java.lang.Math.ceil;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
+@Table(name = "queues")
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor
 @Getter

--- a/app/src/test/java/com/joonhyeok/app/concert/ConcertControllerIntegrateTest.java
+++ b/app/src/test/java/com/joonhyeok/app/concert/ConcertControllerIntegrateTest.java
@@ -3,11 +3,11 @@ package com.joonhyeok.app.concert;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.joonhyeok.app.concert.domain.Concert;
 import com.joonhyeok.app.concert.domain.ConcertRepository;
-import com.joonhyeok.app.concert.presentation.ConcertController;
 import com.joonhyeok.app.queue.domain.Queue;
 import com.joonhyeok.app.queue.domain.QueueRepository;
 import com.joonhyeok.app.queue.domain.QueueStatus;
 import com.joonhyeok.openapi.models.FindConcertPerformanceDatesResponse;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,31 +15,32 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.LocalDateTime;
 
 import static com.joonhyeok.app.concert.ConcertTestHelper.createConcertWithAvailableSeats;
-import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD;
+import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.RefreshMode.AFTER_EACH_TEST_METHOD;
+import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.RefreshMode.BEFORE_EACH_TEST_METHOD;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@TestPropertySource(locations = "classpath:application-test.yaml")
-@DirtiesContext(classMode = BEFORE_EACH_TEST_METHOD)
+@Sql("/ddl-test.sql")
+@AutoConfigureEmbeddedDatabase(refresh = BEFORE_EACH_TEST_METHOD)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class ConcertControllerIntegrateTest {
-    @Autowired
-    private ConcertController concertController;
 
     @Autowired
     private ConcertRepository concertRepository;
 
     @Autowired
     private QueueRepository queueRepository;
+
     @Autowired
     MockMvc mvc;
 

--- a/app/src/test/java/com/joonhyeok/app/concert/ConcertServiceIntegrateTest.java
+++ b/app/src/test/java/com/joonhyeok/app/concert/ConcertServiceIntegrateTest.java
@@ -7,23 +7,28 @@ import com.joonhyeok.app.concert.application.dto.PerformanceDatesQueryResult;
 import com.joonhyeok.app.concert.application.dto.SeatsQueryResult;
 import com.joonhyeok.app.concert.domain.Concert;
 import com.joonhyeok.app.concert.domain.ConcertRepository;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import jakarta.persistence.EntityNotFoundException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
 
 import static com.joonhyeok.app.concert.ConcertTestHelper.createConcertWithAvailableSeats;
 import static com.joonhyeok.app.concert.ConcertTestHelper.createConcertWithUnavailableSeats;
-import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD;
+import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.RefreshMode.AFTER_EACH_TEST_METHOD;
+import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.RefreshMode.BEFORE_EACH_TEST_METHOD;
 
 @SpringBootTest
 @ActiveProfiles("test")
-@TestPropertySource(locations = "classpath:application-test.yaml")
-@DirtiesContext(classMode = BEFORE_EACH_TEST_METHOD)
+@Sql("/ddl-test.sql")
+@AutoConfigureEmbeddedDatabase(refresh = BEFORE_EACH_TEST_METHOD)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class ConcertServiceIntegrateTest {
     @Autowired
     ConcertService concertService;

--- a/app/src/test/java/com/joonhyeok/app/queue/QueueServiceIntegrateTest.java
+++ b/app/src/test/java/com/joonhyeok/app/queue/QueueServiceIntegrateTest.java
@@ -7,6 +7,7 @@ import com.joonhyeok.app.queue.appication.dto.QueueQuery;
 import com.joonhyeok.app.queue.appication.dto.QueueQueryResult;
 import com.joonhyeok.app.queue.domain.Queue;
 import com.joonhyeok.app.queue.domain.QueueRepository;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
@@ -15,19 +16,22 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static com.joonhyeok.app.queue.domain.QueueStatus.WAIT;
+import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.RefreshMode.AFTER_EACH_TEST_METHOD;
+import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.RefreshMode.BEFORE_EACH_TEST_METHOD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD;
 
 @SpringBootTest
 @ActiveProfiles("test")
-@TestPropertySource(locations = "classpath:application-test.yaml")
-@DirtiesContext(classMode = BEFORE_EACH_TEST_METHOD)
+@Sql("/ddl-test.sql")
+@AutoConfigureEmbeddedDatabase(refresh = BEFORE_EACH_TEST_METHOD)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class QueueServiceIntegrateTest {
 
     @Autowired

--- a/app/src/test/java/com/joonhyeok/app/reservation/MakeReservationServiceConcurrentTest.java
+++ b/app/src/test/java/com/joonhyeok/app/reservation/MakeReservationServiceConcurrentTest.java
@@ -2,19 +2,17 @@ package com.joonhyeok.app.reservation;
 
 import com.joonhyeok.app.concert.domain.Concert;
 import com.joonhyeok.app.concert.domain.ConcertRepository;
-import com.joonhyeok.app.concert.domain.SeatRepository;
 import com.joonhyeok.app.reservation.application.MakeReservationService;
 import com.joonhyeok.app.reservation.application.dto.MakeReservationCommand;
-import com.joonhyeok.app.reservation.domain.ReservationRepository;
 import com.joonhyeok.app.user.User;
 import com.joonhyeok.app.user.UserRepository;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,25 +20,22 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.test.context.jdbc.Sql;
 
 import static com.joonhyeok.app.concert.ConcertTestHelper.createConcertWithAvailableSeats;
+import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.RefreshMode.BEFORE_EACH_TEST_METHOD;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 
 @SpringBootTest
 @ActiveProfiles("test")
-@TestPropertySource(locations = "classpath:application-test.yaml")
-@DirtiesContext(classMode = BEFORE_EACH_TEST_METHOD)
+@Sql("/ddl-test.sql")
+@AutoConfigureEmbeddedDatabase(refresh = BEFORE_EACH_TEST_METHOD)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class MakeReservationServiceConcurrentTest {
 
     @Autowired
     ConcertRepository concertRepository;
-
-    @Autowired
-    ReservationRepository reservationRepository;
-
-    @Autowired
-    SeatRepository seatRepository;
 
     @Autowired
     UserRepository userRepository;
@@ -150,7 +145,7 @@ public class MakeReservationServiceConcurrentTest {
             executorService.submit(() -> {
                 try {
                     //when
-                    makeReservationService.reserve(new MakeReservationCommand((long)(finalI1%50), (long) (finalI1)));
+                    makeReservationService.reserve(new MakeReservationCommand((long) (finalI1 % 50), (long) (finalI1)));
                     success.incrementAndGet();
                 } catch (Exception e) {
                     fail.incrementAndGet();

--- a/app/src/test/java/com/joonhyeok/app/reservation/MakeReservationServiceIntegrateTest.java
+++ b/app/src/test/java/com/joonhyeok/app/reservation/MakeReservationServiceIntegrateTest.java
@@ -8,24 +8,29 @@ import com.joonhyeok.app.reservation.domain.Reservation;
 import com.joonhyeok.app.reservation.domain.ReservationRepository;
 import com.joonhyeok.app.user.User;
 import com.joonhyeok.app.user.UserRepository;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import jakarta.persistence.EntityNotFoundException;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
 
 import static com.joonhyeok.app.concert.ConcertTestHelper.createConcertWithAvailableSeats;
 import static com.joonhyeok.app.concert.ConcertTestHelper.createConcertWithUnavailableSeats;
 import static com.joonhyeok.app.reservation.domain.ReservationStatus.RESERVED;
-import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD;
+import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.RefreshMode.AFTER_EACH_TEST_METHOD;
+import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.RefreshMode.BEFORE_EACH_TEST_METHOD;
+
 
 @SpringBootTest
 @ActiveProfiles("test")
-@TestPropertySource(locations = "classpath:application-test.yaml")
-@DirtiesContext(classMode = BEFORE_EACH_TEST_METHOD)
+@Sql("/ddl-test.sql")
+@AutoConfigureEmbeddedDatabase(refresh = BEFORE_EACH_TEST_METHOD)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class MakeReservationServiceIntegrateTest {
 
     @Autowired
@@ -43,13 +48,16 @@ public class MakeReservationServiceIntegrateTest {
     @Autowired
     MakeReservationService makeReservationService;
 
+
     @Test
     void 선택좌석이_예약가능상태라면_예약할수있다_좌석상태_변경확인() throws Exception {
         //given
         Concert concert = createConcertWithAvailableSeats();
         User user = new User(null);
-        userRepository.save(user);
-        concertRepository.save(concert);
+        User save = userRepository.save(user);
+        System.out.println("save.getId() = " + save.getId());
+
+        Concert saved = concertRepository.save(concert);
 
         //when
         MakeReservationResult result = makeReservationService.reserve(new MakeReservationCommand(1L, 1L));
@@ -68,7 +76,7 @@ public class MakeReservationServiceIntegrateTest {
     void 유저가없다면_예약할수없다() throws Exception {
         //given
         Concert concert = createConcertWithAvailableSeats();
-        concertRepository.save(concert);
+        Concert saved = concertRepository.save(concert);
 
         //when
         //then
@@ -82,8 +90,10 @@ public class MakeReservationServiceIntegrateTest {
         //given
         Concert concert = createConcertWithUnavailableSeats();
         User user = new User(null);
-        userRepository.save(user);
-        concertRepository.save(concert);
+        User save = userRepository.save(user);
+        Concert saved = concertRepository.save(concert);
+
+        System.out.println("save.getId() = " + save.getId());
 
         //when
         //then

--- a/app/src/test/resources/application-test.yaml
+++ b/app/src/test/resources/application-test.yaml
@@ -13,7 +13,15 @@ spring:
       hibernate:
         default_schema: concert-test
         #    database-platform: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.PostgreSQLDialect
 
+zonky:
+  test:
+    database:
+      postgres:
+        client:
+          properties:
+            currentSchema: concert-test
 #logging:
 #  level:
 #    org.hibernate.orm.jdbc.bind: trace

--- a/app/src/test/resources/application-test.yaml
+++ b/app/src/test/resources/application-test.yaml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto:
 
     properties:
       hibernate:

--- a/app/src/test/resources/ddl-test.sql
+++ b/app/src/test/resources/ddl-test.sql
@@ -1,0 +1,332 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 16.4 (Homebrew)
+-- Dumped by pg_dump version 16.4 (Homebrew)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: concert-test; Type: SCHEMA; Schema: -; Owner: postgres
+--
+
+CREATE SCHEMA "concert-test";
+
+
+ALTER SCHEMA "concert-test" OWNER TO postgres;
+
+SET default_tablespace = '';
+
+
+--
+-- Name: concert; Type: TABLE; Schema: concert-test; Owner: postgres
+--
+
+CREATE TABLE "concert-test".concert (
+                                        concerts_id bigint NOT NULL,
+                                        performer character varying(255)
+);
+
+
+ALTER TABLE "concert-test".concert OWNER TO postgres;
+
+--
+-- Name: concert_seq; Type: SEQUENCE; Schema: concert-test; Owner: postgres
+--
+
+CREATE SEQUENCE "concert-test".concert_seq
+    START WITH 1
+    INCREMENT BY 50
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE "concert-test".concert_seq OWNER TO postgres;
+
+--
+-- Name: performance_date; Type: TABLE; Schema: concert-test; Owner: postgres
+--
+
+CREATE TABLE "concert-test".performance_date (
+                                                 performance_dates_dates date,
+                                                 concerts_id bigint,
+                                                 performance_dates_id bigint NOT NULL
+);
+
+
+ALTER TABLE "concert-test".performance_date OWNER TO postgres;
+
+--
+-- Name: performance_date_seq; Type: SEQUENCE; Schema: concert-test; Owner: postgres
+--
+
+CREATE SEQUENCE "concert-test".performance_date_seq
+    START WITH 1
+    INCREMENT BY 50
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE "concert-test".performance_date_seq OWNER TO postgres;
+
+--
+-- Name: queues; Type: TABLE; Schema: concert-test; Owner: postgres
+--
+
+CREATE TABLE "concert-test".queues (
+                                       entered_at timestamp(6) without time zone,
+                                       expire_at timestamp(6) without time zone,
+                                       id bigint NOT NULL,
+                                       issue_at timestamp(6) without time zone,
+                                       last_requested_at timestamp(6) without time zone,
+                                       queues_user_id character varying(255) NOT NULL,
+                                       queues_wait_id character varying(255) NOT NULL,
+                                       status character varying(255),
+                                       CONSTRAINT queues_status_check CHECK (((status)::text = ANY ((ARRAY['WAIT'::character varying, 'ACTIVE'::character varying, 'EXPIRED'::character varying])::text[])))
+);
+
+
+ALTER TABLE "concert-test".queues OWNER TO postgres;
+
+--
+-- Name: queues_seq; Type: SEQUENCE; Schema: concert-test; Owner: postgres
+--
+
+CREATE SEQUENCE "concert-test".queues_seq
+    START WITH 1
+    INCREMENT BY 50
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE "concert-test".queues_seq OWNER TO postgres;
+
+--
+-- Name: reservation; Type: TABLE; Schema: concert-test; Owner: postgres
+--
+
+CREATE TABLE "concert-test".reservation (
+                                            created_at timestamp(6) without time zone,
+                                            modified_at timestamp(6) without time zone,
+                                            reservations_id bigint NOT NULL,
+                                            resrvations_seat_id bigint NOT NULL,
+                                            resrvations_user_id bigint NOT NULL,
+                                            reservations_status character varying(255) NOT NULL,
+                                            CONSTRAINT reservation_reservations_status_check CHECK (((reservations_status)::text = ANY ((ARRAY['RESERVED'::character varying, 'PAYED'::character varying, 'CANCELLED'::character varying])::text[])))
+);
+
+
+ALTER TABLE "concert-test".reservation OWNER TO postgres;
+
+--
+-- Name: reservation_seq; Type: SEQUENCE; Schema: concert-test; Owner: postgres
+--
+
+CREATE SEQUENCE "concert-test".reservation_seq
+    START WITH 1
+    INCREMENT BY 50
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE "concert-test".reservation_seq OWNER TO postgres;
+
+--
+-- Name: seat; Type: TABLE; Schema: concert-test; Owner: postgres
+--
+
+CREATE TABLE "concert-test".seat (
+                                     version integer,
+                                     last_reserved_at timestamp(6) without time zone,
+                                     performance_dates_id bigint,
+                                     seats_id bigint NOT NULL,
+                                     seats_status character varying(255),
+                                     CONSTRAINT seat_seats_status_check CHECK (((seats_status)::text = ANY ((ARRAY['AVAILABLE'::character varying, 'PENDING'::character varying, 'UNAVAILABLE'::character varying])::text[])))
+);
+
+
+ALTER TABLE "concert-test".seat OWNER TO postgres;
+
+--
+-- Name: seat_seq; Type: SEQUENCE; Schema: concert-test; Owner: postgres
+--
+
+CREATE SEQUENCE "concert-test".seat_seq
+    START WITH 1
+    INCREMENT BY 50
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE "concert-test".seat_seq OWNER TO postgres;
+
+--
+-- Name: user; Type: TABLE; Schema: concert-test; Owner: postgres
+--
+
+CREATE TABLE "concert-test"."user" (
+                                       users_id bigint NOT NULL
+);
+
+
+ALTER TABLE "concert-test"."user" OWNER TO postgres;
+
+--
+-- Name: user_seq; Type: SEQUENCE; Schema: concert-test; Owner: postgres
+--
+
+CREATE SEQUENCE "concert-test".user_seq
+    START WITH 1
+    INCREMENT BY 50
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE "concert-test".user_seq OWNER TO postgres;
+
+--
+-- Data for Name: concert; Type: TABLE DATA; Schema: concert-test; Owner: postgres
+--
+
+
+
+--
+-- Data for Name: performance_date; Type: TABLE DATA; Schema: concert-test; Owner: postgres
+--
+
+
+
+--
+-- Data for Name: queues; Type: TABLE DATA; Schema: concert-test; Owner: postgres
+--
+
+
+
+--
+-- Data for Name: reservation; Type: TABLE DATA; Schema: concert-test; Owner: postgres
+--
+
+
+
+--
+-- Data for Name: seat; Type: TABLE DATA; Schema: concert-test; Owner: postgres
+--
+
+
+
+--
+-- Data for Name: user; Type: TABLE DATA; Schema: concert-test; Owner: postgres
+--
+
+
+
+--
+-- Name: concert_seq; Type: SEQUENCE SET; Schema: concert-test; Owner: postgres
+--
+
+SELECT pg_catalog.setval('"concert-test".concert_seq', 1, false);
+
+
+--
+-- Name: performance_date_seq; Type: SEQUENCE SET; Schema: concert-test; Owner: postgres
+--
+
+SELECT pg_catalog.setval('"concert-test".performance_date_seq', 1, false);
+
+
+--
+-- Name: queues_seq; Type: SEQUENCE SET; Schema: concert-test; Owner: postgres
+--
+
+SELECT pg_catalog.setval('"concert-test".queues_seq', 1, false);
+
+
+--
+-- Name: reservation_seq; Type: SEQUENCE SET; Schema: concert-test; Owner: postgres
+--
+
+SELECT pg_catalog.setval('"concert-test".reservation_seq', 1, false);
+
+
+--
+-- Name: seat_seq; Type: SEQUENCE SET; Schema: concert-test; Owner: postgres
+--
+
+SELECT pg_catalog.setval('"concert-test".seat_seq', 1, false);
+
+
+--
+-- Name: user_seq; Type: SEQUENCE SET; Schema: concert-test; Owner: postgres
+--
+
+SELECT pg_catalog.setval('"concert-test".user_seq', 1, false);
+
+
+--
+-- Name: concert concert_pkey; Type: CONSTRAINT; Schema: concert-test; Owner: postgres
+--
+
+ALTER TABLE ONLY "concert-test".concert
+    ADD CONSTRAINT concert_pkey PRIMARY KEY (concerts_id);
+
+
+--
+-- Name: performance_date performance_date_pkey; Type: CONSTRAINT; Schema: concert-test; Owner: postgres
+--
+
+ALTER TABLE ONLY "concert-test".performance_date
+    ADD CONSTRAINT performance_date_pkey PRIMARY KEY (performance_dates_id);
+
+
+--
+-- Name: queues queues_pkey; Type: CONSTRAINT; Schema: concert-test; Owner: postgres
+--
+
+ALTER TABLE ONLY "concert-test".queues
+    ADD CONSTRAINT queues_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: reservation reservation_pkey; Type: CONSTRAINT; Schema: concert-test; Owner: postgres
+--
+
+ALTER TABLE ONLY "concert-test".reservation
+    ADD CONSTRAINT reservation_pkey PRIMARY KEY (reservations_id);
+
+
+--
+-- Name: seat seat_pkey; Type: CONSTRAINT; Schema: concert-test; Owner: postgres
+--
+
+ALTER TABLE ONLY "concert-test".seat
+    ADD CONSTRAINT seat_pkey PRIMARY KEY (seats_id);
+
+
+--
+-- Name: user user_pkey; Type: CONSTRAINT; Schema: concert-test; Owner: postgres
+--
+
+ALTER TABLE ONLY "concert-test"."user"
+    ADD CONSTRAINT user_pkey PRIMARY KEY (users_id);
+
+
+--
+-- PostgreSQL database dump complete
+--
+


### PR DESCRIPTION
# [zonky](https://github.com/zonkyio/embedded-database-spring-test?tab=readme-ov-file#refreshing-the-database-during-tests) 이용한 테스트 컨테이너 추가
---
# 이슈
## `@AutoConfigureEmbeddedDatabase(refresh = BEFORE_EACH_TEST_METHOD)`
  - 메인테이너가 말하는 것 처럼 완벽하게  기능을 하지 못함.
  - `Primary Key Dup Exception`, `PK값이 -48으로 할당`되거나 하는 이슈 발견
  -  내부적인 clean 로직이 단순하여 시퀀스에 STEP만큼 증감해서 아닐까 사료됨.
  - 기존 `@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)`를 유지하여 정상 동작하도록 변경했음
  - 백그라운드 쓰레드(queue 입장/퇴장 스케쥴러)와 충돌 여부 확인 필요 [이슈 링크](https://arc.net/l/quote/gljglolc) 