### PR TITLE
[feat/log] 파라미터 로깅 기능 추가, 주요 비지니스 상태 로깅 추가

### DIFF
--- a/app/src/main/codegen-config/api-concert-contract.yaml
+++ b/app/src/main/codegen-config/api-concert-contract.yaml
@@ -19,7 +19,7 @@ externalDocs:
   description: Find out more about Swagger
   url: http://swagger.io
 servers:
-  - url: https://petstore3.swagger.io/api/v3
+  - url: localhost:8080
 tags:
   - name: concert
     description: 콘서트 날짜/좌석 정보 작업

--- a/app/src/main/java/com/joonhyeok/app/common/filter/HttpLoggingFilter.java
+++ b/app/src/main/java/com/joonhyeok/app/common/filter/HttpLoggingFilter.java
@@ -1,0 +1,116 @@
+package com.joonhyeok.app.common.filter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.Instant;
+import java.util.Enumeration;
+import java.util.stream.Collectors;
+
+@Component
+public class HttpLoggingFilter implements Filter {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpLoggingFilter.class);
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        logger.info("Initializing HTTP Logging Filter");
+    }
+
+    @Override
+    public void doFilter(
+            jakarta.servlet.ServletRequest request, 
+            jakarta.servlet.ServletResponse response, 
+            FilterChain chain) throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        Instant start = Instant.now(); // 시작 시간 기록
+        String requestBody = getRequestBody(httpRequest); // 요청 본문 읽기
+
+        logRequest(httpRequest, requestBody); // 요청 로깅
+
+        // 응답 필터 체인 실행
+        HttpResponseWrapper wrappedResponse = new HttpResponseWrapper(httpResponse);
+        chain.doFilter(request, wrappedResponse);
+
+        Instant end = Instant.now(); // 종료 시간 기록
+        long duration = java.time.Duration.between(start, end).toMillis(); // 처리 시간 계산
+
+        logResponse(httpRequest, wrappedResponse, duration); // 응답 로깅
+    }
+
+    @Override
+    public void destroy() {
+        logger.info("Destroying HTTP Logging Filter");
+    }
+
+    private String getRequestBody(HttpServletRequest request) {
+        try (BufferedReader reader = request.getReader()) {
+            return reader.lines().collect(Collectors.joining(System.lineSeparator()));
+        } catch (IOException e) {
+            logger.error("Failed to read request body", e);
+            return "Unable to read request body.";
+        }
+    }
+
+    private void logRequest(HttpServletRequest request, String requestBody) {
+        String headers = getHeadersAsString(request);
+        logger.info("HTTP REQUEST - Method: {}, URI: {}, Headers: {}, Body: {}",
+                request.getMethod(), request.getRequestURI(), headers, requestBody);
+    }
+
+    private void logResponse(HttpServletRequest request, HttpResponseWrapper response, long duration) {
+        String headers = response.getHeadersAsString();
+        logger.info("HTTP RESPONSE - URI: {}, Status: {}, Duration: {}ms, Headers: {}, Body: {}",
+                request.getRequestURI(), response.getStatus(), duration, headers, response.getBody());
+    }
+
+    private String getHeadersAsString(HttpServletRequest request) {
+        Enumeration<String> headerNames = request.getHeaderNames();
+        StringBuilder headers = new StringBuilder();
+        while (headerNames.hasMoreElements()) {
+            String name = headerNames.nextElement();
+            String value = request.getHeader(name);
+            headers.append(name).append(": ").append(value).append("; ");
+        }
+        return headers.toString();
+    }
+
+    // HttpServletResponse를 래핑하는 클래스
+    private static class HttpResponseWrapper extends jakarta.servlet.http.HttpServletResponseWrapper {
+
+        private final StringWriter responseWriter = new StringWriter();
+
+        public HttpResponseWrapper(HttpServletResponse response) {
+            super(response);
+        }
+
+        @Override
+        public PrintWriter getWriter() {
+            return new PrintWriter(responseWriter);
+        }
+
+        public String getBody() {
+            return responseWriter.toString();
+        }
+
+        public String getHeadersAsString() {
+            return this.getHeaderNames().stream()
+                    .map(name -> name + ": " + this.getHeader(name))
+                    .collect(Collectors.joining("; "));
+        }
+    }
+}

--- a/app/src/main/java/com/joonhyeok/app/common/filter/HttpLoggingFilter.java
+++ b/app/src/main/java/com/joonhyeok/app/common/filter/HttpLoggingFilter.java
@@ -6,8 +6,7 @@ import jakarta.servlet.FilterConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.io.BufferedReader;
@@ -19,19 +18,19 @@ import java.util.Enumeration;
 import java.util.stream.Collectors;
 
 @Component
+@Slf4j
 public class HttpLoggingFilter implements Filter {
 
-    private static final Logger logger = LoggerFactory.getLogger(HttpLoggingFilter.class);
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
-        logger.info("Initializing HTTP Logging Filter");
+        log.info("Initializing HTTP Logging Filter");
     }
 
     @Override
     public void doFilter(
-            jakarta.servlet.ServletRequest request, 
-            jakarta.servlet.ServletResponse response, 
+            jakarta.servlet.ServletRequest request,
+            jakarta.servlet.ServletResponse response,
             FilterChain chain) throws IOException, ServletException {
 
         HttpServletRequest httpRequest = (HttpServletRequest) request;
@@ -54,27 +53,27 @@ public class HttpLoggingFilter implements Filter {
 
     @Override
     public void destroy() {
-        logger.info("Destroying HTTP Logging Filter");
+        log.info("Destroying HTTP Logging Filter");
     }
 
     private String getRequestBody(HttpServletRequest request) {
         try (BufferedReader reader = request.getReader()) {
             return reader.lines().collect(Collectors.joining(System.lineSeparator()));
         } catch (IOException e) {
-            logger.error("Failed to read request body", e);
+            log.error("Failed to read request body", e);
             return "Unable to read request body.";
         }
     }
 
     private void logRequest(HttpServletRequest request, String requestBody) {
         String headers = getHeadersAsString(request);
-        logger.info("HTTP REQUEST - Method: {}, URI: {}, Headers: {}, Body: {}",
+        log.info("HTTP REQUEST - Method: {}, URI: {}, Headers: {}, Body: {}",
                 request.getMethod(), request.getRequestURI(), headers, requestBody);
     }
 
     private void logResponse(HttpServletRequest request, HttpResponseWrapper response, long duration) {
         String headers = response.getHeadersAsString();
-        logger.info("HTTP RESPONSE - URI: {}, Status: {}, Duration: {}ms, Headers: {}, Body: {}",
+        log.info("HTTP RESPONSE - URI: {}, Status: {}, Duration: {}ms, Headers: {}, Body: {}",
                 request.getRequestURI(), response.getStatus(), duration, headers, response.getBody());
     }
 

--- a/app/src/main/java/com/joonhyeok/app/concert/domain/Seat.java
+++ b/app/src/main/java/com/joonhyeok/app/concert/domain/Seat.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +13,7 @@ import static com.joonhyeok.app.concert.domain.SeatStatus.*;
 import static jakarta.persistence.EnumType.STRING;
 import static lombok.AccessLevel.PROTECTED;
 
+@Slf4j
 @Entity
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor
@@ -47,6 +49,7 @@ public class Seat {
         if (!isReservable()) {
             throw new IllegalStateException("이미 선택된 좌석입니다.");
         }
+        log.info("reserve seat seatId = {}", this.id);
         this.status = PENDING;
     }
 

--- a/app/src/main/java/com/joonhyeok/app/queue/appication/QueuePolicyScheduler.java
+++ b/app/src/main/java/com/joonhyeok/app/queue/appication/QueuePolicyScheduler.java
@@ -14,11 +14,13 @@ public class QueuePolicyScheduler {
 
     @Scheduled(fixedDelay = 1000)
     public void activate() {
+        log.debug("activate queuePolicy");
         queuePolicy.activate();
     }
 
     @Scheduled(fixedDelay = 2500)
     public void expire() {
+        log.debug("expire queuePolicy");
         queuePolicy.expire();
     }
 }

--- a/app/src/main/java/com/joonhyeok/app/reservation/domain/Reservation.java
+++ b/app/src/main/java/com/joonhyeok/app/reservation/domain/Reservation.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -16,6 +17,7 @@ import static com.joonhyeok.app.reservation.domain.ReservationStatus.RESERVED;
 import static jakarta.persistence.EnumType.STRING;
 import static lombok.AccessLevel.PROTECTED;
 
+@Slf4j
 @Entity
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor
@@ -44,9 +46,11 @@ public class Reservation {
         setSeatId(seatId);
         setUserId(userId);
         setCreatedAt(LocalDateTime.now());
+        log.info("new Reservation seatId = {}, userId = {}", seatId, userId);
     }
 
     public void invalidate() {
+        log.info("invalidate reservation reservationId = {}", this.id);
         this.status = ReservationStatus.CANCELLED;
     }
 
@@ -54,6 +58,7 @@ public class Reservation {
         if (!isPayable()) {
             throw new IllegalStateException("결제할 수 없는 예약입니다");
         }
+        log.info("pay confirmed reservationId = {}", this.id);
         this.status = PAYED;
     }
 

--- a/app/src/main/java/com/joonhyeok/app/user/application/UserPayService.java
+++ b/app/src/main/java/com/joonhyeok/app/user/application/UserPayService.java
@@ -53,6 +53,7 @@ public class UserPayService {
             reservation.confirmPay();
             queueRepository.findByUserId(userId).ifPresent(Queue::expire);
         }
+
         return new UserPayResult(reservation.getId());
     }
 }

--- a/app/src/main/java/com/joonhyeok/app/user/domain/Account.java
+++ b/app/src/main/java/com/joonhyeok/app/user/domain/Account.java
@@ -6,11 +6,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
 
 import static lombok.AccessLevel.PROTECTED;
 
+@Slf4j
 @Embeddable
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor
@@ -25,20 +27,27 @@ public class Account {
     private LocalDateTime modifiedAt;
 
     public void deposit(long amount) {
+        log.info("try deposit with amount of {}, current balance = {}", amount, this.balance);
         if (amount <= 0) {
+            log.error("충전 금액은 음수일 수 없습니다. amount = {}", amount);
             throw new IllegalArgumentException("충전 금액은 음수일 수 없습니다. amount = " + amount);
         }
+        log.info("complete deposit with amount of {}, current balance = {}", amount, this.balance);
         this.balance += amount;
         this.modifiedAt = LocalDateTime.now();
     }
 
     public void withdraw(long amount) {
+        log.info("try withdraw with amount of {}, current balance = {}", amount, this.balance);
         if (amount < 0) {
+            log.error("출금 금액은 음수일 수 없습니다. amount = {}", amount);
             throw new IllegalArgumentException("출금 금액은 음수일 수 없습니다. amount = " + amount);
         }
         if (this.balance < amount) {
+            log.error("잔고 이상 출금할 수 없습니다. balance = {}, withdraw amount = {}", this.balance, amount);
             throw new IllegalStateException("잔고 이상 출금할 수 없습니다. balance = " + this.balance + ", withdraw amount = " + amount);
         }
+        log.info("complete withdraw with amount of {}, current balance = {}", amount, this.balance);
         this.balance -= amount;
         this.modifiedAt = LocalDateTime.now();
     }

--- a/app/src/test/java/com/joonhyeok/app/reservation/MakeReservationServiceConcurrentTest2.java
+++ b/app/src/test/java/com/joonhyeok/app/reservation/MakeReservationServiceConcurrentTest2.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @Sql("/ddl-test.sql")
 @AutoConfigureEmbeddedDatabase
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-class MakeReservationServiceConcurrentTest {
+class MakeReservationServiceConcurrentTest2 {
 
     @Autowired
     ConcertRepository concertRepository;


### PR DESCRIPTION
# 작업
- [x] [테스트 컨테이너 적용](https://github.com/hpp-backend-15/java-concert-joonhyeokyang/pull/10)
  - 깃 클론이후 바로 `Postgresql`로 통합 테스트 코드 실행 가능
- [x] 비즈니스 별 발생할 수 있는 에러 코드 정의 및 관리 체계 구축
  - 커스텀 예외 사용 없이 표준 예외로 관리
- [x] 프레임워크별 글로벌 에러 핸들러를 통해 예외 로깅 및 응답 처리 핸들러 구현
  - **글로벌 에러 핸들러** : 이전 PR에서 완료 1840c8c7482b19d1d5ea0a1e9a6fc138ead51b08
- [x] 시스템 성격에 적합하게 Filter, Interceptor 를 활용해 기능의 관점을 분리하여 개선
  - 모든 요청 Request/Response 대한 로깅 추가 
  - **@VerifyWait** AOP를 이용하여 대기가 필요한 핸들러에 적용하면, 해당 `Wait-Token`을 가진 유저가 충분히 대기하여 `ACTIVE`한 유저인지 검증합니다. 349217c3cacfdda16cb475c83cbb5e908b108dfb
- [x] 모든 API 가 정상적으로 기능을 제공하도록 완성
  - [x] 유저 충전/사용/조회 기능 
  - [x] 결제 기능 
---
# 변명

실제로 로깅작업량이 많지 않아 배웠던 점을 아래에 정리하고, 문서화했습니다.
[필터와 인터셉터 문서화](https://github.com/hpp-backend-15/java-concert-joonhyeokyang/blob/main/docs/markdown/6.%20%ED%95%84%ED%84%B0%EC%99%80%20%EC%9D%B8%ED%84%B0%EC%85%89%ED%84%B0.md)

---
## 필터와 인터셉터
Spring은 공통적으로 여러 작업을 처리함으로써, **중복된 코드를 제거할 수 있도록** 많은 기능을 지원하고 있습니다.
개 중에서, **필터(Filter)** 와 **인터셉터(Interfceptor)** 를 정리합니다.

### 1. 필터
필터는 J2EE 표준 스펙 기능으로 **디스패처 서블릿(Dispatcher Servlet)** 에 요청이 전달되기 전/후에 url 패턴에 맞는 모든 요청에 대해 부가 작업을 처리할 수 있는 기능을 제공합니다.

**디스패처 서블릿** 은 스프링의 가장 앞단에 존재하는 프론트 컨트롤러이므로, 필터는 스프링 범위 밖에서 처리가 됩니다.

- 필터는 리소스에 대한 **요청/응답에 대한 필터 작업** 을 합니다.
- 필터는 `doFilter` 메서드를 통해 필터 작업을 합니다.
- 모든 필터는 초기화 파라미터를 얻을 수 있는 `FilterConfig`에 접근이 가능하고,
- 서블릿 컨텍스트 (ServletRequest/ServletResponse)에 참조 및 사용이 가능합니다.

#### Init
필터가 **자리해야할 곳을 표시**하고 서비스에 배치하기 위해 **웹 컨테이너** 로 부터 호출됩니다.
<img width="932" alt="image" src="https://github.com/user-attachments/assets/b7d0193b-1815-4828-975e-b93504def25c">

서블릿 컨테이너는 필터가 인스턴스화된 뒤 정확히 한번 호출합니다. 필터 작업을 하기전, **필터 초기화(init)**가 성공적으로 완료되어야 합니다. 웹 컨테이너는 **초기화** 메서드가 1. `ServletException`을 던지거나, 2. 웹컨테이너가 사전 지정한 시간 내에 종료(return)하지 않으면, 서비스에 배치 할 수 없습니다.

#### doFilter
필터의 `doFilter` 메서드는 체인 끝의 리소스에 대한 클라이언트 요청으로 인해 요청/응답 쌍이 체인을 통과할 때마다 컨테이너에서 호출됩니다.
(좀 의역해보자면, 체인 끝의 리소스-> 디스패쳐 서블릿 이후 접근하고자 하는 리소스이므로, 클라이언트 요청/응답마다 필터 체인의 필터의 `doFilter`메서드가 컨테이너에 의해 실행된다.. 정도)

이 메서드에 전달된 **필터 체인** 을 통해 **필터** 는 **체인의 다음 개체** 에 요청과 응답을 전달할 수 있습니다.

주로 이 메서드는 주로 다음과 같이 구현됩니다.
1. 요청값 검사
2. (옵션) 요청 객체를 `입력 필터링`에 맞게 직접 구현한 필터 내용이나 헤더로 바꾸기
3. (옵션) 요청 객체를 `출력 필터링`에 맞게 직접 구현한 필터 내용이나 헤더로 바꾸기
4. 아래 둘 중 하나 작업
	1. `FilterChain` 객체를 이용하여 체인의 다음 개체(`entity`)를 호출 (`chain, doFilter()`)
	2. 체인의 다음 객체에 요청/응답 값을 보내지 않고, 요청을 차단해버림
5. 필터 체인의 다음 개체를 호출하며 직접 헤더를 지정(`set`)

#### destroy
웹 컨테이너가 서비스에서 필터를 제외시켰다는 것을 나타내기위해 호출합니다.

이 메서드는 필터들의 `doFilter`메서드가 끝나거나, `timeout`이 지났을 때 모든 쓰레드에서 한번만 호출됩니다.
웹 컨테이너가 이 메서드를 호출하면, 이 필터의 인스턴스에서 `doFilter`를 다시는 요청하지 않습니다.

이 메서드는 필터에게 잡혀있는 자원(ex 메모리, 파일 핸들러, 쓰레드)을 모두 정리할 기회를 줍니다. 그리고 어떤 영속적인 상태도 메모리 상 필터의 현재 상태와 동기화되도록 합니다. (🤔 아마 모든 쓰레드에서 모두 동기화 된다는 의미인듯?)


### 2. 인터셉터
먼저, 우리가 부르는 **인터셉터**들은 `**HandlerInterceptor**`의 구현체이다. `**HandlerInterceptor**`는 `**HandlerMapping**`의 구현된 핸들러의 요청을 가로챈다(Intercept). 그래서, 공통된 요청을 가로질러 기능을 적용하고자 할때 유용하다.

**HandlerInterceptor** 인터페이스는 다음 세 메서드를 구현한다.

#### preHandle() 
`boolean`값을 반환하는 실제 핸들러가 실행되기 전 콜백 메서드이다. 만약 `true` 라면 계속 실행하고, `false` 라면 그 이후 실행 체인은 우회되고 **핸들러가 실행되지 않는다**

#### postHandle() 
핸들러 실행 이후 콜백 메서드이다.

#### afterCompletion()
모든 요청이 끝난 뒤 콜백이다.

[추가]
인터셉터는 J2EE 표준 스펙인 [[Filter]]와 달리, **Spring이 제공하는 기술로써** , 디스패쳐 서블릿이 컨트롤러를 호출하기 전과 후에 요청과 응답을 참조/가공하는 기능을 제공한다. 즉, 웹 컨테이너(서블릿 컨테이너)에서 동작하는 필터와는 달리 인터셉터는 스프링 컨텍스트에서 동작한다. 디스패쳐 서블렛은 핸들러 매핑을 통해 적절한 컨트롤러를 찾도록 요청하는데, 그 결과로 실행 체인(HandlerExecutionChain)을 돌려준다. 그래서 이 실행 체인은 1개 이상의 인터셉터가 등록되어 있다면, 순차적으로 인터셉터들을 거쳐 컨트롤러가 실행되도록 하고, 인터셉터가 없다면 바로 컨트롤러를 실행한다.
<img width="709" alt="image" src="https://github.com/user-attachments/assets/653a9db3-d819-42ba-b162-fc4aa00753b0">

\*HandlerMapping: `@GetMapping` (이런식)  핸들러를 지정해주는 역할
디스패쳐 서블릿은 프론트 컨트롤러로서 핸들러 인스턴스를 맵과 같은 자료구조에 저장한다.
이후 url 패턴에 맞는 요청이 오면 해당 클래스를 반환 한 뒤 실행한다.


# 출처
- [MangKyu's Diary:티스토리](https://mangkyu.tistory.com/173)
- https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-servlet/handlermapping-interceptor.html
