### PR TITLE
[test/concurrent] 예약 동시성 테스트 케이스 추가 

### DIFF
--- a/app/src/test/java/com/joonhyeok/app/reservation/MakeReservationServiceConcurrentTest2.java
+++ b/app/src/test/java/com/joonhyeok/app/reservation/MakeReservationServiceConcurrentTest2.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @Sql("/ddl-test.sql")
 @AutoConfigureEmbeddedDatabase
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-class MakeReservationServiceConcurrentTest {
+class MakeReservationServiceConcurrentTest2 {
 
     @Autowired
     ConcertRepository concertRepository;


### PR DESCRIPTION
# 작업
- [x] 시나리오별 동시성 통합 테스트 작성 
  - 예약 관련 동시성 통합 테스트 작성

---
# 동시성 통합 테스트
동시성 통합 테스트가 저번 코치님 조언이었어서, 먼저 커밋돼어있는 파일을 끌어올렸습니다... (ㅠㅠ)
작성된 테스트는 세가지입니다.

1. 한 유저가 한 좌석을 동시에 300번 예약 시도하는 경우 (1번 성공)
- 한 유저가 한 좌석을 300번 예약 시도하는 케이스입니다. 예약시 좌석에 낙관락을 적용하여 방지하였습니다.
2. 300명의 유저가 한 좌석에 1번씩 예약 시도하는 경우 (1번 성공)
- 300명의 유저중 단 한 명만 예약에 성공합니다.
3. 300명의 유저가 여러 좌석을 동시에 예약시도 하는 경우(좌석수==성공수)
- 300명의 유저가 50개의 좌석을 두고 경쟁하며 예약 시도합니다.
- 성공수는 좌석의 수인 50개임을 검증하는 테스트입니다.

---
# 리뷰 포인트
위의 테스트가 과제에서 요구한 `시나리오별 동시성 통합 테스트 작성`에 부합하는 내용인가요?